### PR TITLE
feat: align embed viewport styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ Marp `theme: default` + `class: invert` などダーク系スライドに調和�
     overflow:hidden;
     max-width:960px;
     margin:0 auto;
+    --embed-frame-width:min(100%, 960px);
   "
 >
   <iframe
     src="https://example.com/?scene=euclidean-hinge&embed=1"
-    style="width:100%;aspect-ratio:16/9;border:none;"
+    style="width:100%;aspect-ratio:16/9;border:none;display:block;"
     title="Euclidean hinge scene"
     allow="fullscreen"
   ></iframe>

--- a/src/ui/scenes/layouts.tsx
+++ b/src/ui/scenes/layouts.tsx
@@ -25,26 +25,31 @@ const CANVAS_FRAME_STYLE: CSSProperties = {
     boxShadow: "0 8px 24px rgba(0,0,0,0.3)",
 };
 
+const EMBED_FRAME_WIDTH = "var(--embed-frame-width, 100vw)";
+
 const CANVAS_FRAME_EMBED_STYLE: CSSProperties = {
     ...CANVAS_FRAME_STYLE,
-    width: "100%",
+    boxSizing: "border-box",
+    width: EMBED_FRAME_WIDTH,
     height: "auto",
-    maxWidth: `${STANDARD_CANVAS_WIDTH}px`,
+    maxWidth: EMBED_FRAME_WIDTH,
     aspectRatio: "16 / 9",
+    border: "1px solid rgba(148, 163, 184, 0.35)",
     boxShadow: "0 12px 32px rgba(15,23,42,0.45)",
+};
+
+const EMBED_CONTAINER_STYLE: CSSProperties = {
+    boxSizing: "border-box",
+    width: EMBED_FRAME_WIDTH,
+    margin: "0 auto",
+    padding: 0,
+    display: "block",
 };
 
 export function SceneLayout({ controls, canvas, embed }: SceneLayoutProps): JSX.Element {
     if (embed) {
         return (
-            <div
-                style={{
-                    ...BASE_CONTAINER_STYLE,
-                    justifyItems: "center",
-                    alignItems: "center",
-                    padding: "24px",
-                }}
-            >
+            <div style={EMBED_CONTAINER_STYLE}>
                 <div style={CANVAS_FRAME_EMBED_STYLE}>{canvas}</div>
             </div>
         );

--- a/src/ui/stories/EmbeddedScene.stories.tsx
+++ b/src/ui/stories/EmbeddedScene.stories.tsx
@@ -24,6 +24,12 @@ type EmbeddedSceneProps = {
     sceneId: SceneId;
 };
 
+const STORY_EMBED_WRAPPER_STYLE = {
+    "--embed-frame-width": "min(100%, 960px)",
+    width: "100%",
+    margin: "0 auto",
+} as CSSProperties;
+
 function EmbeddedPlanarScene({
     scene,
     scenes,
@@ -79,10 +85,18 @@ function EmbeddedScene({ sceneId }: EmbeddedSceneProps): JSX.Element {
     const scene = useMemo(() => getSceneDefinition(sceneId), [sceneId]);
 
     if (scene.geometry === GEOMETRY_KIND.spherical) {
-        return <EmbeddedSphericalScene scene={scene} scenes={scenes} />;
+        return (
+            <div style={STORY_EMBED_WRAPPER_STYLE}>
+                <EmbeddedSphericalScene scene={scene} scenes={scenes} />
+            </div>
+        );
     }
 
-    return <EmbeddedPlanarScene scene={scene} scenes={scenes} />;
+    return (
+        <div style={STORY_EMBED_WRAPPER_STYLE}>
+            <EmbeddedPlanarScene scene={scene} scenes={scenes} />
+        </div>
+    );
 }
 
 function EmbeddedSceneIframe({ sceneId }: EmbeddedSceneProps): JSX.Element {
@@ -95,7 +109,7 @@ function EmbeddedSceneIframe({ sceneId }: EmbeddedSceneProps): JSX.Element {
         if (!doc) return;
         doc.open();
         doc.write(
-            `<!doctype html><html><head><style>html,body{margin:0;background:#111827;height:100%;overflow:hidden;}#root{width:100%;height:100%;display:flex;align-items:center;justify-content:center;overflow:hidden;background:#111827;border:1px solid rgba(148,163,184,0.35);border-radius:12px;box-shadow:0 12px 32px rgba(15,23,42,0.45);}</style></head><body><div id="root"></div></body></html>`,
+            `<!doctype html><html><head><style>:root{--embed-frame-width:100vw;}html,body{margin:0;background:#111827;height:100%;min-height:100vh;overflow:hidden;}#root{width:100%;min-height:100vh;}</style></head><body><div id="root"></div></body></html>`,
         );
         doc.close();
         const mountNode = doc.getElementById("root");

--- a/src/ui/utils/queryParams.ts
+++ b/src/ui/utils/queryParams.ts
@@ -7,8 +7,9 @@ export type SceneEmbedQuery = {
 
 const EMBED_CLASS = "embed-mode";
 const EMBED_BACKGROUND = "#111827";
-const EMBED_BORDER = "1px solid rgba(148, 163, 184, 0.35)";
 const ROOT_ELEMENT_ID = "root";
+const EMBED_FRAME_WIDTH_VAR = "--embed-frame-width";
+const EMBED_FRAME_WIDTH_VALUE = "100vw";
 
 function hasWindow(): boolean {
     return typeof window !== "undefined" && typeof window.location !== "undefined";
@@ -79,15 +80,18 @@ export function applyEmbedClass(embed: boolean): void {
     if (!root) return;
     if (embed) {
         root.style.backgroundColor = EMBED_BACKGROUND;
-        root.style.border = EMBED_BORDER;
-        root.style.borderRadius = "12px";
-        root.style.boxShadow = "0 12px 32px rgba(15, 23, 42, 0.45)";
-        root.style.overflow = "hidden";
+        root.style.width = "100%";
+        root.style.minHeight = "100vh";
     } else {
         root.style.backgroundColor = "";
-        root.style.border = "";
-        root.style.borderRadius = "";
-        root.style.boxShadow = "";
-        root.style.overflow = "";
+        root.style.width = "";
+        root.style.minHeight = "";
+    }
+
+    const docElement = document.documentElement;
+    if (embed) {
+        docElement.style.setProperty(EMBED_FRAME_WIDTH_VAR, EMBED_FRAME_WIDTH_VALUE);
+    } else {
+        docElement.style.removeProperty(EMBED_FRAME_WIDTH_VAR);
     }
 }


### PR DESCRIPTION
Closes #131

## 目的（Why）
- 背景/課題: `?embed=1` で表示したときにキャンバス背景とブラウザの余白がずれて見た目が崩れる。Storybook の埋め込みプレビューとも外観が一致していなかった。
- 目標: 実アプリと Storybook の両方で埋め込みビューがビューポート幅に揃い、余白なく表示されるようにする。

## 変更点（What）
- 埋め込みレイアウトを CSS カスタムプロパティ経由で制御し、ビューポート幅と同期
- `applyEmbedClass` でルート要素へ CSS 変数を付与/削除し Storybook でも上書きできるよう調整
- Storybook の埋め込みストーリーと README の埋め込み例を新スタイルに合わせて更新

### 技術詳細（How）
- `--embed-frame-width` をデフォルト 100vw とし、埋め込み時のラッパーはブロック要素に変更
- Storybook では同じ CSS 変数を `min(100%, 960px)` で上書きし、iframe 内 HTML でも変数を初期化
- ルート要素の装飾は外し `SceneLayout` 側で枠線/影を保持することでズレを排除

## スクリーンショット / 動作デモ（任意）
- Storybook: `Scenes/Embedded Preview` の `Default` / `AllScenes`
- 実アプリ: `/?scene=euclidean-hinge&embed=1`

## 受け入れ条件（DoD）
- [x] 目的を満たすユーザーストーリーが確認できる
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` が緑（coverage v8）
- [ ] 重要分岐のユニット/プロパティテストが追加されている（既存テストでカバー）
- [x] README/Docs/Storybook（該当時）が更新されている
- [ ] アクセシビリティ: ラベル/フォーカス/キーボードが機能し重大違反なし（UI 操作なしのため影響なし）

## 確認手順（Reviewer 向け）
```bash
pnpm i
pnpm lint
pnpm typecheck
pnpm test
pnpm storybook # Storybook で Scenes/Embedded Preview を確認
```

## リスクとロールバック
- 影響範囲: embed モードのレイアウト、Storybook の埋め込みプレビュー
- リスク/懸念: レスポンシブ幅の変更が将来のレイアウトに影響する可能性
- ロールバック指針: `src/ui/utils/queryParams.ts` と `src/ui/scenes/layouts.tsx` の変更を戻す

## Out of Scope（別PR）
- Storybook 以外のドキュメント更新
- Embed モード以外の UI レイアウト改善

## 関連 Issue / PR
- Refs #131

## 追加メモ（任意）
- プロジェクト連携: Issue #131 を Done へ
- リリースノート案: embed モードの表示を実アプリと埋め込みプレビューで統一
